### PR TITLE
Address feedback from patroni's 624 issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,7 +142,7 @@ patroni_postgresql_replica_method: "" #TODO
 # http://patroni.readthedocs.io/en/latest/watchdog.html
 patroni_watchdog_mode: automatic
 patroni_watchdog_device: /dev/watchdog
-patroni_watchdog_safety_margin: -1
+patroni_watchdog_safety_margin: 5
 
 patroni_tags:
   - { name: "nofailover",    value: "false" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ patroni_namespace: /service/
 patroni_scope: main
 
 # http://patroni.readthedocs.io/en/latest/SETTINGS.html#rest-api
-patroni_restapi_connect_address: 127.0.0.1:8008
+patroni_restapi_connect_address: "{{ ansible_host }}:8008"
 patroni_restapi_listen: 0.0.0.0:8008
 patroni_restapi_certfile: ""
 patroni_restapi_keyfile: ""


### PR DESCRIPTION
1) `restapi.connect_address` must be accessible from outside for proper leader election process and patronictl commands.
2) Use positive value of `watchdog.safety_margin` to prevent split-brain scenario by restarting non-supervised postgres node before the leader key expiration.