### PR TITLE
Get rid of deprecation warnings to comply with ansible 2.4

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 
-- include: user.yml
+- import_tasks: user.yml
 
 - name: Create patroni config directory
   file: 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,7 +25,7 @@
   with_items:
     - "{{ patroni_pkg_dependencies }}"
 
-- include: watchdog.yml
+- import_tasks: watchdog.yml
   when: patroni_watchdog_mode in ('automatic', 'required')
 
 - name: Install patroni

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,10 @@
   include_vars: "{{ ansible_os_family }}.yml"
   tags: [patroni, patroni-install, patroni-configure]
 
-- include: install.yml
+- import_tasks: install.yml
   tags: [patroni, patroni-install]
 
-- include: configure.yml
+- import_tasks: configure.yml
   tags: [patroni, patroni-configure]
 
 - name: Ensure patroni is running


### PR DESCRIPTION
Use static inclusion of tasks with `import_tasks` to replace outdated behavior in Ansible 2.3 and below.