### PR TITLE
Allow multiple hosts for etcd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,8 @@ patroni_restapi_password: ""
 patroni_dcs: etcd
 
 # http://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd
-patroni_etcd_host: 127.0.0.1:2379
+patroni_etcd_host: ""
+patroni_etcd_hosts: 127.0.0.1:2379
 patroni_etcd_url: ""
 patroni_etcd_proxy: ""
 patroni_etcd_srv: ""

--- a/templates/etcd.yml.j2
+++ b/templates/etcd.yml.j2
@@ -1,5 +1,10 @@
 etcd:
-  host: {{ patroni_etcd_host | default('127.0.0.1:2379') }}
+{% if not( (patroni_etcd_host is none) or (patroni_etcd_host | trim == '') ) %}
+  host: {{ patroni_etcd_host }}
+{% endif %}
+{% if not( (patroni_etcd_hosts is none) or (patroni_etcd_hosts | trim == '') ) %}
+  hosts: {{ patroni_etcd_hosts }}
+{% endif %}
 {% if not( (patroni_etcd_url is none) or (patroni_etcd_url | trim == '') ) %}
   url: {{ patroni_etcd_url }}
 {% endif %}


### PR DESCRIPTION
Starting from Patroni 1.4 it is possible to specify multiple etcd nodes in configuration file via `etcd.hosts` variable. This parameter should contain the initial list of hosts that will be used to discover and populate the list of the running etcd cluster members.