### PR TITLE
Change retr0h.etcd to andrewrothstein.etcd-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Coming soon.
 ## Dependencies
 
   _Depending on your preferences, you can use one of the following Ansible roles to setup etcd, Consul or ZooKeeper cluster:_
-* [**retr0h.etcd**](https://github.com/retr0h/ansible-etcd)
+* [**andrewrothstein.etcd-cluster**](https://github.com/andrewrothstein/ansible-etcd-cluster)
 * [**brianshumate.consul**](https://github.com/brianshumate/ansible-consul)
 * [**AnsibleShipyard.ansible-zookeeper**](https://github.com/AnsibleShipyard/ansible-zookeeper)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,7 @@ dependencies:
   - role: brianshumate.consul
     when: patroni_dcs == "consul" and
           not patroni_dcs_exists
-  - role: retr0h.etcd
+  - role: andrewrothstein.etcd-cluster
     when: patroni_dcs == "etcd" and
           not patroni_dcs_exists
   - role: AnsibleShipyard.ansible-zookeeper

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: brianshumate.consul
 
-- src: retr0h.etcd
+- src: andrewrothstein.etcd-cluster
 
 - src: AnsibleShipyard.ansible-zookeeper


### PR DESCRIPTION
Please review pull request.

retr0h.etcd not supported and get error
```
Unable to start service etcd: Job for etcd.service failed because the control process exited with error code. See "systemctl status etcd.service" and "journalctl -xe" for details.

Nov 24 22:12:07 ubuntu etcd[17126]: --initial-cluster must include patroni3=http://127.0.0.1:2380 given --initial-advertise-peer-urls=http://127.0.0.1:2380
Nov 24 22:12:07 ubuntu systemd[1]: etcd.service: Main process exited, code=exited, status=1/FAILURE
```