### PR TITLE
Add support of permanent replication slots

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,10 @@ patroni_bootstrap_dcs_synchronous_mode: false
 patroni_bootstrap_dcs_postgresql_use_pg_rewind: true
 patroni_bootstrap_dcs_postgresql_use_slots: true
 
+patroni_bootstrap_dcs_slots: []
+#  - { name: "permanent_physical_1", type: "physical" }
+#  - { name: "permanent_logical_1",  type: "logical", database: "foo", plugin: "pgoutput" }
+
 patroni_bootstrap_dcs_postgresql_parameters:
   - { option: "max_connections",           value: "100" }
   - { option: "max_locks_per_transaction", value: "64" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,10 +86,6 @@ patroni_bootstrap_dcs_synchronous_mode: false
 patroni_bootstrap_dcs_postgresql_use_pg_rewind: true
 patroni_bootstrap_dcs_postgresql_use_slots: true
 
-patroni_bootstrap_dcs_slots: []
-#  - { name: "permanent_physical_1", type: "physical" }
-#  - { name: "permanent_logical_1",  type: "logical", database: "foo", plugin: "pgoutput" }
-
 patroni_bootstrap_dcs_postgresql_parameters:
   - { option: "max_connections",           value: "100" }
   - { option: "max_locks_per_transaction", value: "64" }
@@ -105,6 +101,10 @@ patroni_bootstrap_dcs_postgresql_parameters:
 patroni_bootstrap_dcs_postgresql_recovery_conf: []
 #  - { option: "standby_mode",    value: "on" }
 #  - { option: "restore_command", value: "cp ../wal_archive/%f %p" }
+
+patroni_bootstrap_dcs_slots: []
+#  - { name: "permanent_physical_1", type: "physical" }
+#  - { name: "permanent_logical_1",  type: "logical", database: "foo", plugin: "pgoutput" }
 
 # http://patroni.readthedocs.io/en/latest/replica_bootstrap.html#bootstrap
 patroni_bootstrap_method_name: ""

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -29,17 +29,6 @@ bootstrap:
     postgresql:
       use_pg_rewind: {{ patroni_bootstrap_dcs_postgresql_use_pg_rewind |string |d(true, true) |replace(None, true) |lower }}
       use_slots: {{ patroni_bootstrap_dcs_postgresql_use_slots |string |d(true, true) |replace(None, true) |lower }}
-    {% if patroni_bootstrap_dcs_slots |d([], true) |length > 0 %}
-      slots:
-      {% for slot in patroni_bootstrap_dcs_slots %}
-        {{ slot.name }}:
-          type: {{ slot.type }}
-        {% if slot.type == 'logical' %}
-          database: {{ slot.database }}
-          plugin: {{ slot.plugin }}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
     {% if patroni_bootstrap_dcs_postgresql_parameters |d([], true) |length > 0 %}
       parameters:
       {% for guc in patroni_bootstrap_dcs_postgresql_parameters %}
@@ -52,6 +41,17 @@ bootstrap:
         {{ item.option }}: {{ item.value }}
       {% endfor %}
     {% endif %}
+  {% if patroni_bootstrap_dcs_slots |d([], true) |length > 0 %}
+    slots:
+    {% for slot in patroni_bootstrap_dcs_slots %}
+      {{ slot.name }}:
+        type: {{ slot.type }}
+      {% if slot.type == 'logical' %}
+        database: {{ slot.database }}
+        plugin: {{ slot.plugin }}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 {% if patroni_bootstrap_method_name |d(None, true) and patroni_bootstrap_method_command |d(None, true) %}
   method: {{ patroni_bootstrap_method_name }}
   {{ patroni_bootstrap_method_name }}:

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -29,6 +29,17 @@ bootstrap:
     postgresql:
       use_pg_rewind: {{ patroni_bootstrap_dcs_postgresql_use_pg_rewind |string |d(true, true) |replace(None, true) |lower }}
       use_slots: {{ patroni_bootstrap_dcs_postgresql_use_slots |string |d(true, true) |replace(None, true) |lower }}
+    {% if patroni_bootstrap_dcs_slots |d([], true) |length > 0 %}
+      slots:
+      {% for slot in patroni_bootstrap_dcs_slots %}
+        {{ slot.name }}:
+          type: {{ slot.type }}
+        {% if slot.type == 'logical' %}
+          database: {{ slot.database }}
+          plugin: {{ slot.plugin }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     {% if patroni_bootstrap_dcs_postgresql_parameters |d([], true) |length > 0 %}
       parameters:
       {% for guc in patroni_bootstrap_dcs_postgresql_parameters %}


### PR DESCRIPTION
Slots defined in `bootstrap.dcs.slots` will be preserved during switchover or failover.