### PR TITLE
Allow ExecStartPre to be configured

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ patroni_config_dir: /etc/patroni
 patroni_system_user: postgres
 patroni_system_group: postgres
 
+patroni_exec_start_pre: "/bin/mkdir -m 2750 -p /var/run/postgresql/{{ patroni_postgresql_version }}-main.pg_stat_tmp"
+
 patroni_system_packages:
   - { name: "python-pip", state: "present" }
   - { name: "jq",         state: "present" }

--- a/templates/patroni.service.j2
+++ b/templates/patroni.service.j2
@@ -19,7 +19,7 @@ Environment='PATRONI_LOGFORMAT={{ patroni_logformat }}'
 Environment='PATRONI_LOGLEVEL={{ patroni_loglevel }}'
 Environment='PATRONI_REQUESTS_LOGLEVEL={{ patroni_requests_loglevel }}'
 
-ExecStartPre={{ patroni_exec_stat_pre | default('') }}
+ExecStartPre={{ patroni_exec_start_pre | default('') }}
 ExecStart={{ patroni_bin_dir }}/patroni {{ patroni_config_dir }}/{{ patroni_name|default(inventory_hostname) }}.yml
 
 # only kill the patroni process, not it's children, so it will gracefully stop postgres

--- a/templates/patroni.service.j2
+++ b/templates/patroni.service.j2
@@ -19,6 +19,7 @@ Environment='PATRONI_LOGFORMAT={{ patroni_logformat }}'
 Environment='PATRONI_LOGLEVEL={{ patroni_loglevel }}'
 Environment='PATRONI_REQUESTS_LOGLEVEL={{ patroni_requests_loglevel }}'
 
+ExecStartPre={{ patroni_exec_stat_pre | default('') }}
 ExecStart={{ patroni_bin_dir }}/patroni {{ patroni_config_dir }}/{{ patroni_name|default(inventory_hostname) }}.yml
 
 # only kill the patroni process, not it's children, so it will gracefully stop postgres


### PR DESCRIPTION
Postgres was failing to start due to a missing temporary file pg_stat_tmp. This is a work around to allow the creation of the temporary file using the ExecStartPre field is which is executed before the Patroni service is started. 

To implement the workaround users must set the variable:
```
patroni_exec_stat_pre: "/bin/mkdir -m 2750 -p /var/run/postgresql/{{ patroni_postgresql_version }}-main.pg_stat_tmp"
```

Related issues:
https://serverfault.com/questions/881064/postgres-9-5-main-pg-stat-tmp-no-such-file-or-directory
https://github.com/zalando/patroni/issues/1005