### PR TITLE
Support of synchronous_mode_strict option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,6 +92,7 @@ patroni_bootstrap_dcs_retry_timeout: 10
 patroni_bootstrap_dcs_maximum_lag_on_failover: 1048576
 patroni_bootstrap_dcs_master_start_timeout: 300
 patroni_bootstrap_dcs_synchronous_mode: false
+patroni_bootstrap_dcs_synchronous_mode_strict: false
 patroni_bootstrap_dcs_check_timeline: false
 patroni_bootstrap_dcs_standby_cluster:
   - { option: "host",                     value: "" }

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -43,6 +43,7 @@ bootstrap:
     maximum_lag_on_failover: {{ patroni_bootstrap_dcs_maximum_lag_on_failover |d(1048576, true) |int }}
     master_start_timeout: {{ patroni_bootstrap_dcs_master_start_timeout |d(300, true) |int }}
     synchronous_mode: {{ patroni_bootstrap_dcs_synchronous_mode |d(false, true) |lower }}
+    synchronous_mode_strict: {{ patroni_bootstrap_dcs_synchronous_mode_strict |d(false, true) |lower }}
     check_timeline: {{ patroni_bootstrap_dcs_check_timeline |d(false, true) |lower }}
   {% if patroni_bootstrap_dcs_standby_cluster |map(attribute='value') |join() |trim |length > 0 %}
     standby_cluster:


### PR DESCRIPTION
This parameter prevents Patroni from switching off the synchronous replication on the primary when no synchronous standby candidates are available.