### PR TITLE
Add pg_ident.conf support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,6 +125,9 @@ patroni_bootstrap_dcs_postgresql_pg_hba: []
 #  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "ident", options: "map=omicron" }
 #  - { type: "host", database: "replication", user: "{{ patroni_replication_username }}", address: "0.0.0.0/0", method: "md5" }
 
+patroni_bootstrap_dcs_postgresql_pg_ident: []
+#  - { mapname: "omicron", sysuser: "robert", pguser: "bob" }
+
 patroni_bootstrap_dcs_slots: []
 #  - { name: "permanent_physical_1", type: "physical" }
 #  - { name: "permanent_logical_1",  type: "logical", database: "foo", plugin: "pgoutput" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,7 +122,7 @@ patroni_bootstrap_dcs_postgresql_recovery_conf: []
 #  - { option: "restore_command", value: "cp ../wal_archive/%f %p" }
 
 patroni_bootstrap_dcs_postgresql_pg_hba: []
-#  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "md5" }
+#  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "ident", options: "map=omicron" }
 #  - { type: "host", database: "replication", user: "{{ patroni_replication_username }}", address: "0.0.0.0/0", method: "md5" }
 
 patroni_bootstrap_dcs_slots: []
@@ -142,7 +142,7 @@ patroni_bootstrap_initdb:
   - { option: "data-checksums" }
 
 patroni_bootstrap_pg_hba: []
-#  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "md5" }
+#  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "ident", options: "map=omicron" }
 #  - { type: "host", database: "replication", user: "{{ patroni_replication_username }}", address: "0.0.0.0/0", method: "md5" }
 
 patroni_bootstrap_post_bootstrap: "" #TODO
@@ -196,8 +196,11 @@ patroni_postgresql_parameters:
   - { option: "unix_socket_directories", value: "/var/run/postgresql" }
 
 patroni_postgresql_pg_hba: []
-#  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "md5" }
+#  - { type: "host", database: "all",         user: "all",                                address: "0.0.0.0/0", method: "ident", options: "map=omicron" }
 #  - { type: "host", database: "replication", user: "{{ patroni_replication_username }}", address: "0.0.0.0/0", method: "md5" }
+
+patroni_postgresql_pg_ident: []
+#  - { mapname: "omicron", sysuser: "robert", pguser: "bob" }
 
 patroni_postgresql_pg_ctl_timeout: 60
 

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -72,6 +72,12 @@ bootstrap:
         - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }} {{ client.options |d(None) }}
       {% endfor %}
     {% endif %}
+    {% if patroni_bootstrap_dcs_postgresql_pg_ident |d([], true) |length > 0 %}
+      pg_ident:
+      {% for map in patroni_bootstrap_dcs_postgresql_pg_ident %}
+        - {{ map.mapname }} {{ map.sysuser }} {{ map.pguser }}
+      {% endfor %}
+    {% endif %}
   {% if patroni_bootstrap_dcs_slots |d([], true) |length > 0 %}
     slots:
     {% for slot in patroni_bootstrap_dcs_slots %}

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -69,7 +69,7 @@ bootstrap:
     {% if patroni_bootstrap_dcs_postgresql_pg_hba |d([], true) |length > 0 %}
       pg_hba:
       {% for client in patroni_bootstrap_dcs_postgresql_pg_hba %}
-        - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }}
+        - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }} {{ client.options |d(None) }}
       {% endfor %}
     {% endif %}
   {% if patroni_bootstrap_dcs_slots |d([], true) |length > 0 %}
@@ -108,7 +108,7 @@ bootstrap:
 {% if patroni_bootstrap_pg_hba |d([], true) |length > 0 %}
   pg_hba:
   {% for client in patroni_bootstrap_pg_hba %}
-    - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }}
+    - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }} {{ client.options |d(None) }}
   {% endfor %}
 {% endif %}
 {% if patroni_bootstrap_post_bootstrap |d(None, true) %}
@@ -197,7 +197,13 @@ postgresql:
 {% if patroni_postgresql_pg_hba |d([], true) |length > 0 %}
   pg_hba:
   {% for client in patroni_postgresql_pg_hba %}
-    - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }}
+    - {{ client.type }} {{ client.database }} {{ client.user }} {{ client.address |d(None) }} {{ client.method }} {{ client.options |d(None) }}
+  {% endfor %}
+{% endif %}
+{% if patroni_postgresql_pg_ident |d([], true) |length > 0 %}
+  pg_ident:
+  {% for map in patroni_postgresql_pg_ident %}
+    - {{ map.mapname }} {{ map.sysuser }} {{ map.pguser }}
   {% endfor %}
 {% endif %}
   pg_ctl_timeout: {{ patroni_postgresql_pg_ctl_timeout |d(60, true) |int }}


### PR DESCRIPTION
Starting from Patroni 1.6.0 it is possible to manage pg_ident.conf similarly to pg_hba.conf.