### PR TITLE
New parameter : patroni_backup_on_copy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ patroni_config_dir: /etc/patroni
 patroni_system_user: postgres
 patroni_system_group: postgres
 
+# create a backup file before copying files on hosts
+patroni_backup_on_copy: true
+
 patroni_exec_start_pre: "/bin/mkdir -m 2750 -p /var/run/postgresql/{{ patroni_postgresql_version }}-main.pg_stat_tmp"
 
 patroni_pip_packages:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,7 +24,7 @@
     owner: "{{ patroni_system_user }}"
     group: "{{ patroni_system_group }}"
     mode: 0750
-    backup: yes
+    backup: "{{ patroni_backup_on_copy }}"
   with_items:
     - "{{ patroni_postgresql_callbacks }}"
   when: not( (item.script is none) or (item.script | trim | length == 0) )


### PR DESCRIPTION
Hi @kostiantyn-nemchenko !

Here's a basic patch to decide if callback copy task should make backups or not.

I left the default value to `true` so that the role behaviour won't change for existing users.

Closes #77