### PR TITLE
Allow variables overwrite from group_vars/host_vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ patroni_postgresql_version: 11
 patroni_postgresql_exists: false
 
 patroni_config_dir: /etc/patroni
+patroni_config_file: "{{ inventory_hostname }}.yml"
 patroni_system_user: postgres
 patroni_system_group: postgres
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,7 +40,7 @@
 - name: Create patroni configuration file
   template:
     src: patroni.yml.j2
-    dest: "{{ patroni_config_dir }}/{{ patroni_name|default(inventory_hostname) }}.yml"
+    dest: "{{ patroni_config_dir }}/{{ patroni_config_file }}"
     owner: "{{ patroni_system_user }}"
     group: "{{ patroni_system_group }}"
     mode: 0600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
-
-- name: Include OS-specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
-  tags: [patroni, patroni-install, patroni-configure]
+- include_tasks: variables.yml
 
 - import_tasks: install.yml
   tags: [patroni, patroni-install]

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,0 +1,72 @@
+---
+- name: Include OS-specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+  tags: [patroni, patroni-install, patroni-configure]
+
+- name: Define Debian specific facts
+  block:
+    - name: Define postgresql_apt_key_url.
+      set_fact:
+        postgresql_apt_key_url: "{{ __postgresql_apt_key_url }}"
+      when: postgresql_apt_key_url is not defined
+
+    - name: Define postgresql_apt_repo.
+      set_fact:
+        postgresql_apt_repo: "{{ __postgresql_apt_repo }}"
+      when: postgresql_apt_repo is not defined
+  when: ansible_os_family == 'Debian'
+
+- name: Define RedHat specific facts
+  block:
+    - name: Define postgresql_yum_repo_url.
+      set_fact:
+        postgresql_yum_repo_url: "{{ __postgresql_yum_repo_url }}"
+      when: postgresql_yum_repo_url is not defined
+
+    - name: Define postgresql_yum_repo_pkg_name.
+      set_fact:
+        postgresql_yum_repo_pkg_name: "{{ __postgresql_yum_repo_pkg_name }}"
+      when: postgresql_yum_repo_pkg_name is not defined
+
+    - name: Define postgresql_yum_repo_pkg_version.
+      set_fact:
+        postgresql_yum_repo_pkg_version: "{{ __postgresql_yum_repo_pkg_version }}"
+      when: postgresql_yum_repo_pkg_version is not defined
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution != 'Fedora'
+
+- name: Define patroni_postgresql_packages.
+  set_fact:
+    patroni_postgresql_packages: "{{ __patroni_postgresql_packages | list }}"
+  when: patroni_postgresql_packages is not defined
+
+- name: Define patroni_system_packages.
+  set_fact:
+    patroni_system_packages: "{{ __patroni_system_packages | list }}"
+  when: patroni_system_packages is not defined
+
+- name: Define patroni_postgresql_data_dir.
+  set_fact:
+    patroni_postgresql_data_dir: "{{ __patroni_postgresql_data_dir }}"
+  when: patroni_postgresql_data_dir is not defined
+
+- name: Define patroni_postgresql_config_dir.
+  set_fact:
+    patroni_postgresql_config_dir: "{{ __patroni_postgresql_config_dir }}"
+  when: patroni_postgresql_config_dir is not defined
+
+- name: Define patroni_postgresql_bin_dir.
+  set_fact:
+    patroni_postgresql_bin_dir: "{{ __patroni_postgresql_bin_dir }}"
+  when: patroni_postgresql_bin_dir is not defined
+
+- name: Define patroni_postgresql_pgpass.
+  set_fact:
+    patroni_postgresql_pgpass: "{{ __patroni_postgresql_pgpass }}"
+  when: patroni_postgresql_pgpass is not defined
+
+- name: Define patroni_bin_dir.
+  set_fact:
+    patroni_bin_dir: "{{ __patroni_bin_dir }}"
+  when: patroni_bin_dir is not defined

--- a/templates/patroni.service.j2
+++ b/templates/patroni.service.j2
@@ -16,7 +16,7 @@ Group={{ patroni_system_group }}
 # StandardOutput=syslog
 
 ExecStartPre={{ patroni_exec_start_pre | default('') }}
-ExecStart={{ patroni_bin_dir }}/patroni {{ patroni_config_dir }}/{{ patroni_name|default(inventory_hostname) }}.yml
+ExecStart={{ patroni_bin_dir }}/patroni {{ patroni_config_dir }}/{{ patroni_config_file }}
 
 # only kill the patroni process, not it's children, so it will gracefully stop postgres
 KillMode=process

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,21 +1,21 @@
 ---
 
-postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-postgresql_apt_repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+__postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+__postgresql_apt_repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
 
-patroni_postgresql_data_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"
-patroni_postgresql_config_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"
-patroni_postgresql_bin_dir: "/usr/lib/postgresql/{{ patroni_postgresql_version }}/bin"
-patroni_postgresql_pgpass: /var/lib/postgresql/.pgpass
-patroni_bin_dir: /usr/local/bin
+__patroni_postgresql_data_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"
+__patroni_postgresql_config_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"
+__patroni_postgresql_bin_dir: "/usr/lib/postgresql/{{ patroni_postgresql_version }}/bin"
+__patroni_postgresql_pgpass: /var/lib/postgresql/.pgpass
+__patroni_bin_dir: /usr/local/bin
 
-patroni_postgresql_packages:
+__patroni_postgresql_packages:
   - { name: "postgresql-{{ patroni_postgresql_version }}",            state: "present" }
   - { name: "postgresql-client-{{ patroni_postgresql_version }}",     state: "present" }
   - { name: "postgresql-contrib-{{ patroni_postgresql_version }}",    state: "present" }
   - { name: "postgresql-server-dev-{{ patroni_postgresql_version }}", state: "present" }
 
-patroni_system_packages:
+__patroni_system_packages:
   - { name: "python3-psycopg2", state: "present" }
   - { name: "python3-pip",      state: "present" }
   - { name: "jq",              state: "present" }

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,22 +1,22 @@
 ---
 
-postgresql_yum_repo_url: "https://yum.postgresql.org/{{ patroni_postgresql_version }}/{{ 'fedora' if ansible_distribution|lower == 'fedora' else 'redhat' }}/{{ 'fedora' if ansible_distribution|lower == 'fedora' else 'rhel' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}"
-postgresql_yum_repo_pkg_name: pgdg-redhat-repo-latest.noarch.rpm
-postgresql_yum_repo_pkg_version: 11.5-1PGDG.rhel7
+__postgresql_yum_repo_url: "https://yum.postgresql.org/{{ patroni_postgresql_version }}/{{ 'fedora' if ansible_distribution|lower == 'fedora' else 'redhat' }}/{{ 'fedora' if ansible_distribution|lower == 'fedora' else 'rhel' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}"
+__postgresql_yum_repo_pkg_name: pgdg-redhat-repo-latest.noarch.rpm
+__postgresql_yum_repo_pkg_version: 11.5-1PGDG.rhel7
 
-patroni_postgresql_data_dir: "/var/lib/pgsql/{{ patroni_postgresql_version }}/data"
-patroni_postgresql_config_dir: "/var/lib/pgsql/{{ patroni_postgresql_version }}/data"
-patroni_postgresql_bin_dir: "/usr/pgsql-{{ patroni_postgresql_version }}/bin"
-patroni_postgresql_pgpass: /var/lib/pgsql/.pgpass
-patroni_bin_dir: /usr/local/bin
+__patroni_postgresql_data_dir: "/var/lib/pgsql/{{ patroni_postgresql_version }}/data"
+__patroni_postgresql_config_dir: "/var/lib/pgsql/{{ patroni_postgresql_version }}/data"
+__patroni_postgresql_bin_dir: "/usr/pgsql-{{ patroni_postgresql_version }}/bin"
+__patroni_postgresql_pgpass: /var/lib/pgsql/.pgpass
+__patroni_bin_dir: /usr/local/bin
 
-patroni_postgresql_packages:
+__patroni_postgresql_packages:
   - { name: "postgresql{{ patroni_postgresql_version|replace('.','') }}-{{ postgresql_yum_repo_pkg_version }}",         state: "present" }
   - { name: "postgresql{{ patroni_postgresql_version|replace('.','') }}-server-{{ postgresql_yum_repo_pkg_version }}",  state: "present" }
   - { name: "postgresql{{ patroni_postgresql_version|replace('.','') }}-contrib-{{ postgresql_yum_repo_pkg_version }}", state: "present" }
   - { name: "postgresql{{ patroni_postgresql_version|replace('.','') }}-devel-{{ postgresql_yum_repo_pkg_version }}",   state: "present" }
 
-patroni_system_packages:
+__patroni_system_packages:
   - { name: "epel-release",     state: "present" }
   - { name: "gcc",              state: "present" }
   - { name: "python3-devel",    state: "present" }


### PR DESCRIPTION
The current implementation is loading variables from vars/ directory
when the role is evaluated. Doing so prevent user to overwrite them in
their group_vars/host_vars. A user can have several patroni clusters
targeted by the same playbook, example:

```yaml
- name: Configure PostgreSQL
  hosts: role_patroni_server
  any_errors_fatal: true
  become: true
  become_user: root
  roles:
    - kostiantyn-nemchenko.patroni
```

This PR follow the same implementation used by Jeff Geerling in each of
its roles (kudos to him).