### PR TITLE
Fix: The yum repository link has been changed

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-__postgresql_yum_repo_url: "https://yum.postgresql.org/{{ patroni_postgresql_version }}/{{ 'fedora' if ansible_distribution|lower == 'fedora' else 'redhat' }}/{{ 'fedora' if ansible_distribution|lower == 'fedora' else 'rhel' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}"
+__postgresql_yum_repo_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ 'F' if ansible_distribution|lower == 'fedora' else 'EL' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}"
 __postgresql_yum_repo_pkg_name: pgdg-redhat-repo-latest.noarch.rpm
 __postgresql_yum_repo_pkg_version: 11.5-1PGDG.rhel7
 


### PR DESCRIPTION
Hello, 

Feel free to correct me on how to write this PR it's my first :) 

Bug : 

```log
fatal: [postgres1]: FAILED! => {"changed": false, "msg": "Failure downloading https://yum.postgresql.org/common/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm, HTTP Error 404: Not Found"}
```

Caused by : 

Reorganisation repository of Postgres : https://yum.postgresql.org/news/new-repo-rpms-released/

Solution : 

Modify the URL and the value of the ansible_distribution condition in the vars / RedHat.yml file.

