### PR TITLE
Fix: Packages dependencies and variable in RedHat.yml.

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-__postgresql_yum_repo_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ 'F' if ansible_distribution|lower == 'fedora' else 'EL' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}"
+__postgresql_yum_repo_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ 'F' if ansible_distribution|lower == 'fedora' else 'EL' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ __postgresql_yum_repo_pkg_name }}"
 __postgresql_yum_repo_pkg_name: pgdg-redhat-repo-latest.noarch.rpm
 __postgresql_yum_repo_pkg_version: 11.5-1PGDG.rhel7
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -17,6 +17,9 @@ __patroni_postgresql_packages:
   - { name: "postgresql{{ patroni_postgresql_version|replace('.','') }}-devel-{{ postgresql_yum_repo_pkg_version }}",   state: "present" }
 
 __patroni_system_packages:
+  - { name: "centos-release-scl-rh",  state: "present" }
+  - { name: "llvm-toolset-7-clang",   state: "present" }
+  - { name: "python-setuptools",      state: "present" }
   - { name: "epel-release",     state: "present" }
   - { name: "gcc",              state: "present" }
   - { name: "python3-devel",    state: "present" }


### PR DESCRIPTION
Hello, 

Hello, I noticed that two underscores were missing for the variable: postgresql_yum_repo_pkg_name in the url __postgresql_yum_repo_url

**Bug :** 

```log
fatal: [postgres1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: https://download.postgresql.org/pub/repos/yum/reporpms/{{ 'F' if ansible_distribution|lower == 'fedora' else 'EL' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}: 'postgresql_yum_repo_pkg_name' is undefined\n\nThe error appears to be in '/Users/cyril.tavian/.cache/molecule/wrapper_postgres-ha/default/roles/patroni/tasks/variables.yml': line 21, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Define postgresql_yum_repo_url.\n      ^ here\n"}
```

**Solution :** 

Add __ in front of the variable. 

```yml
__postgresql_yum_repo_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ 'F' if ansible_distribution|lower == 'fedora' else 'EL' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ __postgresql_yum_repo_pkg_name }}"
```

I also have dependencies that are not resolved for python3-psycopg2 (tested under vagrant):

**Bug :** 

```log
 failed: [postgres2] (item={'name': 'python3-psycopg2', 'state': 'present'}) => {"ansible_loop_var": "item", "changed": false, "changes": {"installed": ["python3-psycopg2"]}, "item": {"name": "python3-psycopg2", "state": "present"}, "msg": "Error: Package: postgresql11-devel-11.11-1PGDG.rhel7.x86_64 (pgdg11)\n           Requires: llvm-toolset-7-clang >= 4.0.1\n", "rc": 1, "results": ["Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\n * base: centos.mirror.ate.info\n * epel: mirrors.ukfast.co.uk\n * extras: centos.crazyfrogs.org\n * updates: centos.quelquesmots.fr\nResolving Dependencies\n--> Running transaction check\n---> Package python3-psycopg2.x86_64 0:2.8.6-1.rhel7 will be installed\n--> Processing Dependency: libpq5 >= 10.0 for package: python3-psycopg2-2.8.6-1.rhel7.x86_64\n--> Running transaction check\n---> Package postgresql11-libs.x86_64 0:11.5-1PGDG.rhel7 will be updated\n--> Processing Dependency: postgresql11-libs(x86-64) = 11.5-1PGDG.rhel7 for package: postgresql11-server-11.5-1PGDG.rhel7.x86_64\n--> Processing Dependency: postgresql11-libs(x86-64) = 11.5-1PGDG.rhel7 for package: postgresql11-11.5-1PGDG.rhel7.x86_64\n--> Processing Dependency: postgresql11-libs(x86-64) = 11.5-1PGDG.rhel7 for package: postgresql11-devel-11.5-1PGDG.rhel7.x86_64\n--> Processing Dependency: postgresql11-libs(x86-64) = 11.5-1PGDG.rhel7 for package: postgresql11-contrib-11.5-1PGDG.rhel7.x86_64\n---> Package postgresql11-libs.x86_64 0:11.11-1PGDG.rhel7 will be an update\n--> Running transaction check\n---> Package postgresql11.x86_64 0:11.5-1PGDG.rhel7 will be updated\n---> Package postgresql11.x86_64 0:11.11-1PGDG.rhel7 will be an update\n---> Package postgresql11-contrib.x86_64 0:11.5-1PGDG.rhel7 will be updated\n---> Package postgresql11-contrib.x86_64 0:11.11-1PGDG.rhel7 will be an update\n---> Package postgresql11-devel.x86_64 0:11.5-1PGDG.rhel7 will be updated\n---> Package postgresql11-devel.x86_64 0:11.11-1PGDG.rhel7 will be an update\n--> Processing Dependency: llvm5.0-devel >= 5.0 for package: postgresql11-devel-11.11-1PGDG.rhel7.x86_64\n--> Processing Dependency: llvm-toolset-7-clang >= 4.0.1 for package: postgresql11-devel-11.11-1PGDG.rhel7.x86_64\n---> Package postgresql11-server.x86_64 0:11.5-1PGDG.rhel7 will be updated\n---> Package postgresql11-server.x86_64 0:11.11-1PGDG.rhel7 will be an update\n--> Running transaction check\n---> Package llvm5.0-devel.x86_64 0:5.0.1-7.el7 will be installed\n--> Processing Dependency: llvm5.0(x86-64) = 5.0.1-7.el7 for package: llvm5.0-devel-5.0.1-7.el7.x86_64\n--> Processing Dependency: libedit-devel for package: llvm5.0-devel-5.0.1-7.el7.x86_64\n--> Processing Dependency: libLLVM-5.0.so()(64bit) for package: llvm5.0-devel-5.0.1-7.el7.x86_64\n--> Processing Dependency: libLTO.so.5()(64bit) for package: llvm5.0-devel-5.0.1-7.el7.x86_64\n---> Package postgresql11-devel.x86_64 0:11.11-1PGDG.rhel7 will be an update\n--> Processing Dependency: llvm-toolset-7-clang >= 4.0.1 for package: postgresql11-devel-11.11-1PGDG.rhel7.x86_64\n--> Running transaction check\n---> Package libedit-devel.x86_64 0:3.0-12.20121213cvs.el7 will be installed\n--> Processing Dependency: ncurses-devel for package: libedit-devel-3.0-12.20121213cvs.el7.x86_64\n---> Package llvm5.0.x86_64 0:5.0.1-7.el7 will be installed\n---> Package llvm5.0-libs.x86_64 0:5.0.1-7.el7 will be installed\n---> Package postgresql11-devel.x86_64 0:11.11-1PGDG.rhel7 will be an update\n--> Processing Dependency: llvm-toolset-7-clang >= 4.0.1 for package: postgresql11-devel-11.11-1PGDG.rhel7.x86_64\n--> Running transaction check\n---> Package ncurses-devel.x86_64 0:5.9-14.20130511.el7_4 will be installed\n---> Package postgresql11-devel.x86_64 0:11.11-1PGDG.rhel7 will be an update\n--> Processing Dependency: llvm-toolset-7-clang >= 4.0.1 for package: postgresql11-devel-11.11-1PGDG.rhel7.x86_64\n--> Finished Dependency Resolution\n You could try using --skip-broken to work around the problem\n You could try running: rpm -Va --nofiles --nodigest\n"]}
```
``` Requires: llvm-toolset-7-clang >= 4.0.1```

**Solution :** 

Install 'llvm-toolset-7-clang' from 'centos-release-scl-rh' 
Add the following packages to Redhat.yml first in the list

```yml
          - { name: "centos-release-scl-rh",  state: "present" }
          - { name: "llvm-toolset-7-clang",   state: "present" }
```

And module missing for python : setuptools. 

**Bug :** 

```log
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named pkg_resources
    failed: [postgres1] (item={'name': 'setuptools', 'state': 'latest', 'umask': '0022', 'executable': 'pip3'}) => {"ansible_loop_var": "item", "changed": false, "item": {"executable": "pip3", "name": "setuptools", "state": "latest", "umask": "0022"}, "msg": "Failed to import the required Python library (setuptools) on postgres1's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
    An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named pkg_resources
    failed: [postgres2] (item={'name': 'setuptools', 'state': 'latest', 'umask': '0022', 'executable': 'pip3'}) => {"ansible_loop_var": "item", "changed": false, "item": {"executable": "pip3", "name": "setuptools", "state": "latest", "umask": "0022"}, "msg": "Failed to import the required Python library (setuptools) on postgres2's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
    An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named pkg_resources
    failed: [postgres1] (item={'name': 'patroni[consul]', 'state': 'present', 'umask': '0022', 'executable': 'pip3'}) => {"ansible_loop_var": "item", "changed": false, "item": {"executable": "pip3", "name": "patroni[consul]", "state": "present", "umask": "0022"}, "msg": "Failed to import the required Python library (setuptools) on postgres1's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
    An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named pkg_resources
    failed: [postgres2] (item={'name': 'patroni[consul]', 'state': 'present', 'umask': '0022', 'executable': 'pip3'}) => {"ansible_loop_var": "item", "changed": false, "item": {"executable": "pip3", "name": "patroni[consul]", "state": "present", "umask": "0022"}, "msg": "Failed to import the required Python library (setuptools) on postgres2's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```

**Solution :** 

Add package ```python-setuptools```to RedHat.yml 

```yml
- { name: "python-setuptools",      state: "present" }
```
