### PR TITLE
Fix: Change the order of variable declarations

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -18,15 +18,16 @@
 
 - name: Define RedHat specific facts
   block:
-    - name: Define postgresql_yum_repo_url.
-      set_fact:
-        postgresql_yum_repo_url: "{{ __postgresql_yum_repo_url }}"
-      when: postgresql_yum_repo_url is not defined
 
     - name: Define postgresql_yum_repo_pkg_name.
       set_fact:
         postgresql_yum_repo_pkg_name: "{{ __postgresql_yum_repo_pkg_name }}"
       when: postgresql_yum_repo_pkg_name is not defined
+
+    - name: Define postgresql_yum_repo_url.
+      set_fact:
+        postgresql_yum_repo_url: "{{ __postgresql_yum_repo_url }}"
+      when: postgresql_yum_repo_url is not defined
 
     - name: Define postgresql_yum_repo_pkg_version.
       set_fact:


### PR DESCRIPTION
Hello,

**Scenario :**

When running the role for Redhat, the variable ```postgresql_yum_repo_pkg_name is defined``` after the variable ```postgresql_yum_repo_url``` although it has not yet been defined just before.

**Bug :**

```log
fatal: [postgres1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: https://download.postgresql.org/pub/repos/yum/reporpms/{{ 'F' if ansible_distribution|lower == 'fedora' else 'EL' }}-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/{{ postgresql_yum_repo_pkg_name }}: 'postgresql_yum_repo_pkg_name' is undefined\n\nThe error appears to be in '/Users/cyril.tavian/.cache/molecule/wrapper_postgres-ha/default/roles/patroni/tasks/variables.yml': line 21, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Define postgresql_yum_repo_url.\n      ^ here\n"}
```

**Solution :**
Move the variable ```postgresql_yum_repo_pkg_name``` before the variable ```postgresql_yum_repo_url``` so that it is defined.