### PR TITLE
Install patroni from pgdg

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 patroni_postgresql_version: 11
 patroni_postgresql_exists: false
+patroni_install_from_pip: true
 
 patroni_config_dir: /etc/patroni
 patroni_config_file: "{{ inventory_hostname }}.yml"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,6 +7,7 @@
     owner: "{{ patroni_system_user }}"
     group: "{{ patroni_system_group }}"
     mode: 0750
+  when: patroni_install_from_pip
 
 - name: Create patroni log directory
   file:
@@ -36,6 +37,7 @@
     owner: root
     group: root
     mode: 0644
+  when: patroni_install_from_pip
 
 - name: Create patroni configuration file
   template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,7 @@
 ---
 
 - import_tasks: user.yml
+  when: patroni_install_from_pip
 
 - import_tasks: postgresql.yml
   when: not patroni_postgresql_exists
@@ -15,6 +16,7 @@
     update_cache: yes
   with_items:
     - "{{ patroni_system_packages }}"
+  when: patroni_install_from_pip
 
 - name: Install pip packages for patroni
   pip:
@@ -24,3 +26,4 @@
     executable: "{{ item.executable }}"
   with_items:
     - "{{ patroni_pip_packages }}"
+  when: patroni_install_from_pip

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -70,4 +70,18 @@
 - name: Define patroni_bin_dir.
   set_fact:
     patroni_bin_dir: "{{ __patroni_bin_dir }}"
-  when: patroni_bin_dir is not defined
+  when:
+    - patroni_bin_dir is not defined
+    - patroni_install_from_pip
+
+- name: Define patroni_bin_dir.
+  set_fact:
+    patroni_bin_dir: "/usr/bin"
+  when:
+    - patroni_bin_dir is not defined
+    - not patroni_install_from_pip
+
+- name: Override patroni_config_file
+  set_fact:
+    patroni_config_file: "config.yml"
+  when: not patroni_install_from_pip


### PR DESCRIPTION
Fix #82 

We can use packages from pgdg with this minimum config:
```yml
patroni_install_from_pip: false 

patroni_packages:                                                                                   
  - {name: "patroni", state: "present"}                                                             
```