### PR TITLE
Add repo name option

### DIFF
--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -4,10 +4,12 @@
     - name: Configure postgresql repository key
       apt_key:
         url: "{{ postgresql_apt_key_url }}"
+      when: postgresql_apt_key_url != ""
 
     - name: Configure postgresql repository
       apt_repository:
         repo: "{{ postgresql_apt_repo }}"
+        filename: "{{ postgresql_apt_filename }}"
 
     - name: Ensure postgresql database-cluster manager package
       package:

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -14,6 +14,11 @@
       set_fact:
         postgresql_apt_repo: "{{ __postgresql_apt_repo }}"
       when: postgresql_apt_repo is not defined
+
+    - name: Define postgresql_apt_filename.
+      set_fact:
+        postgresql_apt_filename: "{{ __postgresql_apt_filename }"
+      when: postgresql_apt_filename is not defined
   when: ansible_os_family == 'Debian'
 
 - name: Define RedHat specific facts

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,8 @@
 
 __postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 __postgresql_apt_repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
-__postgresql_apt_filename: "apt_postgresql_org_pub_repos_apt.list"
+__postgresql_apt_filename: "apt_postgresql_org_pub_repos_apt"
+
 
 __patroni_postgresql_data_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"
 __patroni_postgresql_config_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,7 @@
 
 __postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
 __postgresql_apt_repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+__postgresql_apt_filename: "apt_postgresql_org_pub_repos_apt.list"
 
 __patroni_postgresql_data_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"
 __patroni_postgresql_config_dir: "/var/lib/postgresql/{{ patroni_postgresql_version }}/{{ patroni_scope }}"


### PR DESCRIPTION
* Add an option `postgresql_apt_repo_name` to set the repo name in /etc/apt/source.list.d
* Don't install apt key if postgresql_apt_key_url is empty