### PR TITLE
Added optional haproxy configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,8 +43,9 @@ patroni_log_loggers:
   - { module: "urllib3",            level: "DEBUG" }
 
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#rest-api
-patroni_restapi_connect_address: "{{ ansible_host }}:8008"
-patroni_restapi_listen: 0.0.0.0:8008
+patroni_restapi_port: 8008
+patroni_restapi_connect_address: "{{ ansible_host }}:{{ patroni_restapi_port }}"
+patroni_restapi_listen: "0.0.0.0:{{ patroni_restapi_port }}"
 patroni_restapi_username: ""
 patroni_restapi_password: ""
 patroni_restapi_certfile: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 patroni_postgresql_version: 11
 patroni_postgresql_exists: false
 patroni_install_from_pip: true
+patroni_install_haproxy: false
 
 patroni_config_dir: /etc/patroni
 patroni_config_file: "{{ inventory_hostname }}.yml"
@@ -227,6 +228,15 @@ patroni_postgresql_remove_data_directory_on_diverged_timelines: false
 patroni_watchdog_mode: automatic # use quotes for 'off' value
 patroni_watchdog_device: /dev/watchdog
 patroni_watchdog_safety_margin: 5
+
+patroni_haproxy_servers: []
+  # - { name: "server1", ip: "10.0.0.1", port: "5432" }
+  # - { name: "server2", ip: "10.0.0.2", port: "5432" }
+  # - { name: "server3", ip: "10.0.0.3", port: "5432" }
+
+patroni_haproxy_leader_listen_port: 5000
+patroni_haproxy_replica_listen_port: 5001
+patroni_haproxy_stats_listen_port: 7000
 
 patroni_tags:
   - { name: "nofailover",    value: "false" }

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,3 +21,10 @@
     state: restarted
     daemon_reload: yes
     enabled: yes
+
+- name: restart haproxy
+  systemd:
+    name: haproxy.service
+    state: restarted
+    daemon_reload: yes
+    enabled: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -48,3 +48,14 @@
     mode: 0600
   notify:
     - restart patroni
+
+- name: Create haproxy configuration file
+  template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart haproxy
+  when: patroni_install_haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,11 @@
     daemon_reload: yes
     enabled: yes
   tags: [patroni]
+
+- name: Ensure haproxy is running
+  systemd:
+    name: haproxy.service
+    state: started
+    daemon_reload: yes
+    enabled: yes
+  when: patroni_install_haproxy

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -54,7 +54,7 @@
 
 - name: Append haproxy to system packages if needed
   set_fact:
-    patroni_system_packages: "{{ patroni_system_packages + __patroni_haproxy_package | list }}"
+    patroni_system_packages: "{{ patroni_system_packages + __patroni_haproxy_packages | list }}"
   when: patroni_install_haproxy
 
 - name: Define patroni_postgresql_data_dir.

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -52,6 +52,11 @@
     patroni_system_packages: "{{ __patroni_system_packages | list }}"
   when: patroni_system_packages is not defined
 
+- name: Append haproxy to system packages if needed
+  set_fact:
+    patroni_system_packages: "{{ patroni_system_packages + __patroni_haproxy_package | list }}"
+  when: patroni_install_haproxy
+
 - name: Define patroni_postgresql_data_dir.
   set_fact:
     patroni_postgresql_data_dir: "{{ __patroni_postgresql_data_dir }}"

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -1,0 +1,35 @@
+global
+        maxconn 100
+
+defaults
+        log     global
+        mode    tcp
+        retries 2
+        timeout client 30m
+        timeout connect 4s
+        timeout server 30m
+        timeout check 5s
+
+listen stats
+        mode http
+        bind *:{{ patroni_haproxy_stats_listen_port }}
+        stats enable
+        stats uri /
+
+listen master
+        bind *:{{ patroni_haproxy_leader_listen_port }}
+        option httpchk OPTIONS /master
+        http-check expect status 200
+        default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+{% for server in patroni_haproxy_servers %}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port 8008
+{% endfor %}
+
+listen replicas
+        bind *:{{ patroni_haproxy_replica_listen_port }}
+        option httpchk OPTIONS /replica
+        http-check expect status 200
+        default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+{% for server in patroni_haproxy_servers %}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port 8008
+{% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -22,7 +22,7 @@ listen master
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port 8008
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}
 {% endfor %}
 
 listen replicas
@@ -31,5 +31,5 @@ listen replicas
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port 8008
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}
 {% endfor %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -22,5 +22,5 @@ __patroni_system_packages:
   - { name: "python3-pip",      state: "present" }
   - { name: "jq",              state: "present" }
 
-__patroni_haproxy_package:
+__patroni_haproxy_packages:
   - { name: "haproxy", state: "present" }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -21,3 +21,6 @@ __patroni_system_packages:
   - { name: "python3-psycopg2", state: "present" }
   - { name: "python3-pip",      state: "present" }
   - { name: "jq",              state: "present" }
+
+__patroni_haproxy_package:
+  - { name: "haproxy", state: "present" }

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -26,3 +26,6 @@ __patroni_system_packages:
   - { name: "python3-psycopg2", state: "present" }
   - { name: "python3-pip",      state: "present" }
   - { name: "jq",               state: "present" }
+
+__patroni_haproxy_package:
+  - { name: "haproxy", state: "present" }

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -27,5 +27,5 @@ __patroni_system_packages:
   - { name: "python3-pip",      state: "present" }
   - { name: "jq",               state: "present" }
 
-__patroni_haproxy_package:
+__patroni_haproxy_packages:
   - { name: "haproxy", state: "present" }


### PR DESCRIPTION
- Disabled by default to avoid breaking existing user configurations
- Template is very basic - didn't want to overwhelm users with lots of options
- List of servers is defined by user. Yes, it can be done by dynamic list derived from group name, but this is just simple and straightforward.

Didn't write any tests, since free travis is gone anyway. I'll probably create branch with molecule testing running on drone.io.

Any comments/suggestions welcome!