### PR TITLE
Added role name into meta

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,7 @@ galaxy_info:
   - patroni
   - availability
   - failover
+  role_name: patroni
 dependencies: []
 #  - role: brianshumate.consul
 #    when: patroni_dcs == "consul" and


### PR DESCRIPTION
Useful when pushing to galaxy since 3.0 (see https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names)