### PR TITLE
Enable SSL in haproxy.cfg if patroni_restapi_certfile is defined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,16 +46,16 @@ patroni_log_loggers:
 patroni_restapi_port: 8008
 patroni_restapi_connect_address: "{{ ansible_host }}:{{ patroni_restapi_port }}"
 patroni_restapi_listen: "0.0.0.0:{{ patroni_restapi_port }}"
-patroni_restapi_username: ""
-patroni_restapi_password: ""
-patroni_restapi_certfile: ""
-patroni_restapi_keyfile: ""
-patroni_restapi_keyfile_password: ""
-patroni_restapi_cafile: ""
-patroni_restapi_ciphers: ""
-patroni_restapi_verify_client: ""
-patroni_restapi_http_extra_headers: ""
-patroni_restapi_https_extra_headers: ""
+# patroni_restapi_username: ""
+# patroni_restapi_password: ""
+# patroni_restapi_certfile: ""
+# patroni_restapi_keyfile: ""
+# patroni_restapi_keyfile_password: ""
+# patroni_restapi_cafile: ""
+# patroni_restapi_ciphers: ""
+# patroni_restapi_verify_client: ""
+# patroni_restapi_http_extra_headers: ""
+# patroni_restapi_https_extra_headers: ""
 
 patroni_dcs: etcd
 patroni_dcs_exists: true

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -22,7 +22,7 @@ listen master
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile is defined %} check-ssl verify none{% endif +%}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile is defined %} check-ssl verify none{% endif %} 
 {% endfor %}
 
 listen replicas
@@ -31,5 +31,5 @@ listen replicas
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile is defined %} check-ssl verify none{% endif +%}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile is defined %} check-ssl verify none{% endif %} 
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -22,7 +22,7 @@ listen master
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile %} check-ssl verify none{% endif +%}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile is defined %} check-ssl verify none{% endif +%}
 {% endfor %}
 
 listen replicas
@@ -31,5 +31,5 @@ listen replicas
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile %} check-ssl verify none{% endif +%}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile is defined %} check-ssl verify none{% endif +%}
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -22,7 +22,7 @@ listen master
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile %} check-ssl verify none{% endif +%}
 {% endfor %}
 
 listen replicas
@@ -31,5 +31,5 @@ listen replicas
         http-check expect status 200
         default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {% for server in patroni_haproxy_servers %}
-        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}
+        server {{ server.name }} {{ server.ip }}:{{ server.port }} maxconn 100 check port {{ patroni_restapi_port }}{% if patroni_restapi_certfile %} check-ssl verify none{% endif +%}
 {% endfor %}


### PR DESCRIPTION
Fixes #103

Will enable "check-ssl verify none" in haproxy.cfg if a certificate for the REST-API is defined