### PR TITLE
fix: use quote for postgresql parameter in yaml config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ patroni_exec_start_pre: "/bin/mkdir -m 2750 -p /var/run/postgresql/{{ patroni_po
 
 patroni_pip_packages:
   - { name: "setuptools",                 state: "latest",  umask: "0022", executable: "pip3" }
-  - { name: "patroni[{{ patroni_dcs }}]", state: "present", umask: "0022", executable: "pip3" }
+  - { name: "patroni[{{ patroni_dcs }}]=={{ patroni_binary_version }}", state: "present", umask: "0022", executable: "pip3" }
 
 patroni_replication_username: replicator
 patroni_replication_password: repuserpasswd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+patroni_binary_version: "2.1.5"
 
 patroni_postgresql_version: 11
 patroni_postgresql_exists: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
     state: "{{ item.state }}"
     umask: "{{ item.umask }}"
     executable: "{{ item.executable }}"
+    version: "{{ patroni_binary_version }}"
   with_items:
     - "{{ patroni_pip_packages }}"
   when: patroni_install_from_pip

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,7 +24,6 @@
     state: "{{ item.state }}"
     umask: "{{ item.umask }}"
     executable: "{{ item.executable }}"
-    version: "{{ patroni_binary_version }}"
   with_items:
     - "{{ patroni_pip_packages }}"
   when: patroni_install_from_pip

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -75,7 +75,7 @@ bootstrap:
     {% if patroni_bootstrap_dcs_postgresql_parameters |d([], true) |length > 0 %}
       parameters:
       {% for guc in patroni_bootstrap_dcs_postgresql_parameters %}
-        {{ guc.option }}: {{ guc.value }}
+        {{ guc.option }}: "{{ guc.value }}"
       {% endfor %}
     {% endif %}
     {% if patroni_bootstrap_dcs_postgresql_recovery_conf |d([], true) |length > 0 %}
@@ -215,7 +215,7 @@ postgresql:
 {% if patroni_postgresql_parameters |d([], true) |length > 0 %}
   parameters:
   {% for guc in patroni_postgresql_parameters %}
-    {{ guc.option }}: {{ guc.value }}
+    {{ guc.option }}: "{{ guc.value }}"
   {% endfor %}
 {% endif %}
 {% if patroni_postgresql_pg_hba |d([], true) |length > 0 %}


### PR DESCRIPTION
The Patroni cannot start when it use non-alphanumeric value for value in patroni_postgresql_parameters and patroni_bootstrap_dcs_postgresql_parameters.

The value parts need to be in quotes.

Close #107 